### PR TITLE
バグを修正 #3の対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
@@ -38,11 +38,14 @@ class SearchFragment : Fragment(R.layout.search_fragment) {
             .setOnEditorActionListener { editText, action, _ ->
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
                     editText.text.toString().let {
-                        viewModel.searchResults(it).apply {
-                            adapter.submitList(this)
+                        kotlin.runCatching {
+                            viewModel.searchResults(it).apply {
+                                adapter.submitList(this)
+                            }
+                        }.onSuccess {
+                            return@setOnEditorActionListener true
                         }
                     }
-                    return@setOnEditorActionListener true
                 }
                 return@setOnEditorActionListener false
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
@@ -3,11 +3,13 @@
  */
 package jp.co.yumemi.android.code_check
 
+import android.content.Context.INPUT_METHOD_SERVICE
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -36,6 +38,7 @@ class SearchFragment : Fragment(R.layout.search_fragment) {
 
         binding.searchInputText
             .setOnEditorActionListener { editText, action, _ ->
+                handleKeyEvent(editText)
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
                     editText.text.toString().let {
                         kotlin.runCatching {
@@ -61,6 +64,12 @@ class SearchFragment : Fragment(R.layout.search_fragment) {
         val action = SearchFragmentDirections
             .actionToDetailPage(item)
         findNavController().navigate(action)
+    }
+
+    private fun handleKeyEvent(view: View) {
+        val inputMethodManager =
+            view.context.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
     }
 }
 

--- a/app/src/main/res/layout/detail_fragment.xml
+++ b/app/src/main/res/layout/detail_fragment.xml
@@ -5,104 +5,113 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
-        android:id="@+id/ownerIconView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:contentDescription="@null"
-        android:src="@drawable/jetbrains"
-        app:layout_constraintDimensionRatio="1:1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="240dp" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/nameView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/detail_name_view"
-        android:textColor="@color/black"
-        android:textSize="18sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ownerIconView" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/centerGuid"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
+            <ImageView
+                android:id="@+id/ownerIconView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_margin="16dp"
+                android:contentDescription="@null"
+                android:src="@drawable/jetbrains"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="240dp" />
 
-    <TextView
-        android:id="@+id/languageView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/detail_language_view"
-        android:textColor="@color/black"
-        android:textSize="14sp"
-        app:layout_constraintTop_toBottomOf="@id/nameView"
-        tools:ignore="MissingConstraints" />
+            <TextView
+                android:id="@+id/nameView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/detail_name_view"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ownerIconView" />
 
-    <TextView
-        android:id="@+id/starsView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/detail_stars_view"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/nameView" />
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/centerGuid"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.5" />
 
-    <TextView
-        android:id="@+id/watchersView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/detail_watchers_view"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/starsView" />
+            <TextView
+                android:id="@+id/languageView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/detail_language_view"
+                android:textColor="@color/black"
+                android:textSize="14sp"
+                app:layout_constraintTop_toBottomOf="@id/nameView"
+                tools:ignore="MissingConstraints" />
 
-    <TextView
-        android:id="@+id/forksView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/detail_forks_view"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/watchersView" />
+            <TextView
+                android:id="@+id/starsView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/detail_stars_view"
+                android:textAlignment="textEnd"
+                android:textColor="@color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/centerGuid"
+                app:layout_constraintTop_toBottomOf="@id/nameView" />
 
-    <TextView
-        android:id="@+id/openIssuesView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/detail_open_issue_view"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/forksView" />
+            <TextView
+                android:id="@+id/watchersView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/detail_watchers_view"
+                android:textAlignment="textEnd"
+                android:textColor="@color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/centerGuid"
+                app:layout_constraintTop_toBottomOf="@id/starsView" />
 
+            <TextView
+                android:id="@+id/forksView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/detail_forks_view"
+                android:textAlignment="textEnd"
+                android:textColor="@color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintLeft_toLeftOf="@id/centerGuid"
+                app:layout_constraintTop_toBottomOf="@id/watchersView" />
+
+            <TextView
+                android:id="@+id/openIssuesView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/detail_open_issue_view"
+                android:textAlignment="textEnd"
+                android:textColor="@color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/centerGuid"
+                app:layout_constraintTop_toBottomOf="@id/forksView" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closed #3 
修正内容

検索時に何も入力していない場合クラッシュしていた問題が発覚。
検索時にエラーハンドリングを追加して修正。

画面回転のテスト中にViewが見切れてスクロールできないことが発覚。
回転をオフにするか考慮したが今回は回転可能にしスクロールビューの追加で対応。

検索時にキーボードが閉じず操作性が悪いと判断したため検索時にキーボードが非表示になるメソッドを追加。

メモリリークのテストのため以下のライブラリを導入して確認した。
https://square.github.io/leakcanary/


![メモリリークの確認](https://user-images.githubusercontent.com/46846909/185786950-a27b7b2c-048a-4552-8fa5-fb41f785f7f2.png)


検証内容
以下の既存機能のマニュアルテストでデグレしていないことを確認

何かしらのキーワードを入力
GitHub API（search/repositories）でリポジトリを検索し、結果一覧を概要（リポジトリ名）で表示
特定の結果を選択したら、該当リポジトリの詳細（リポジトリ名、オーナーアイコン、プロジェクト言語、Star 数、Watcher 数、Fork 数、Issue 数）を表示

画面が見切れる場合スクロールが可能である。
検索実行時にキーボードが非表示になる。
未入力検索時にクラッシュしない。
メモリリークが起きていない。（基本動作、画面回転等確認）